### PR TITLE
Revert "patch: bump d2-analysis version with interpretation sort order fix [DHIS2-5472]"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/dhis2/charts-app#readme",
   "dependencies": {
     "d2": "^31.2.1",
-    "d2-analysis": "31.0.8",
+    "d2-analysis": "32.0.2",
     "d2-charts-api": "31.0.9",
     "d2-utilizr": "0.2.13"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,10 +1413,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@31.0.8:
-  version "31.0.8"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-31.0.8.tgz#d6e28d51abb70ddaa8515f3a5368134c9e051b2e"
-  integrity sha512-SWxasPm2Al5uA8mLmBCrGiJclq2YLAVU2Uh30hrm58H5zC9rA+NDHPGzyQ5A9Cix/30y2OIpSoCCKshcZZBMLQ==
+d2-analysis@32.0.2:
+  version "32.0.2"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-32.0.2.tgz#4a803cd0ea614f8a6fca94c8989b388726e29084"
+  integrity sha512-c4UVfk87cjCOenU8AQ4xW3r3yS+O2ZxHtFu18zbfkDIZlxGYYU0YgQ4J26r/t7NQmyl/z61A4THLsT3pUXEm5w==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
Reverts dhis2/charts-app#70

Correct version for master is `32.0.3`, not `31.0.8`